### PR TITLE
Support New Mape Heat Branding

### DIFF
--- a/nuheat/api.py
+++ b/nuheat/api.py
@@ -41,7 +41,7 @@ class NuHeat(object):
             "application": "0"
         }
         data = self.request(
-            url=util.get_auth_url(config=config, brand=self._brand),
+            url=util.get_auth_url(brand=self._brand),
             method="POST",
             data=post_data,
         )
@@ -69,10 +69,7 @@ class NuHeat(object):
         :param params: Querystring parameters
         :param retry: Attempt to re-authenticate and retry request if necessary
         """
-        headers = util.get_request_headers(
-            config=config,
-            brand=self._brand,
-        )
+        headers = util.get_request_headers(brand=self._brand)
 
         if params and self._session_id:
             params['sessionid'] = self._session_id

--- a/nuheat/api.py
+++ b/nuheat/api.py
@@ -1,6 +1,6 @@
 import logging
 import requests
-import nuheat.config as config
+from nuheat import config, util
 from nuheat.thermostat import NuHeatThermostat
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,9 +22,6 @@ class NuHeat(object):
         self.password = password
         self._session_id = session_id
         self._brand = brand if brand in config.BRANDS else config.BRANDS[0]
-        self._api_url = config.API_URL.format(
-            HOSTNAME=config.HOSTNAMES[self._brand],
-        )
 
     def __repr__(self):
         return "<NuHeat username='{}'>".format(self.username)
@@ -44,7 +41,7 @@ class NuHeat(object):
             "application": "0"
         }
         data = self.request(
-            url=config.AUTH_URL.format(API_URL=self._api_url),
+            url=util.get_auth_url(config=config, brand=self._brand),
             method="POST",
             data=post_data,
         )
@@ -72,7 +69,10 @@ class NuHeat(object):
         :param params: Querystring parameters
         :param retry: Attempt to re-authenticate and retry request if necessary
         """
-        headers = config.get_request_headers(brand=self._brand)
+        headers = util.get_request_headers(
+            config=config,
+            brand=self._brand,
+        )
 
         if params and self._session_id:
             params['sessionid'] = self._session_id

--- a/nuheat/api.py
+++ b/nuheat/api.py
@@ -9,7 +9,7 @@ _LOGGER.setLevel(logging.DEBUG)
 
 class NuHeat(object):
 
-    def __init__(self, username, password, session_id=None, brand="NUHEAT"):
+    def __init__(self, username, password, session_id=None, brand=config.NUHEAT):
         """
         Initialize a NuHeat API session
 

--- a/nuheat/config.py
+++ b/nuheat/config.py
@@ -8,16 +8,6 @@ API_URL = "https://{HOSTNAME}/api"
 AUTH_URL = "{API_URL}/authenticate/user"
 THERMOSTAT_URL = "{API_URL}/thermostat"
 
-def get_request_headers(brand="NUHEAT"):
-    brand = brand if brand in BRANDS else BRANDS[0]
-    return {
-        "Content-Type": "application/x-www-form-urlencoded",
-        "Accept": "application/json",
-        "Host": "{HOSTNAME}".format(HOSTNAME=HOSTNAMES[brand]),
-        "DNT": "1",
-        "Origin": "https://{HOSTNAME}/api".format(HOSTNAME=HOSTNAMES[brand]),
-    }
-
 # NuHeat Schedule Modes
 SCHEDULE_RUN = 1
 SCHEDULE_TEMPORARY_HOLD = 2  # hold the target temperature until the next scheduled program

--- a/nuheat/config.py
+++ b/nuheat/config.py
@@ -5,10 +5,6 @@ HOSTNAMES = {
     NUHEAT: "mynuheat.com",
     MAPEHEAT: "mymapeheat.com",
 }
-API_URL = "https://{HOSTNAME}/api"
-
-AUTH_URL = "{API_URL}/authenticate/user"
-THERMOSTAT_URL = "{API_URL}/thermostat"
 
 # NuHeat Schedule Modes
 SCHEDULE_RUN = 1

--- a/nuheat/config.py
+++ b/nuheat/config.py
@@ -1,7 +1,9 @@
-BRANDS = ("NUHEAT", "MAPEHEAT")
+NUHEAT = "NUHEAT"
+MAPEHEAT = "MAPEHEAT"
+BRANDS = (NUHEAT, MAPEHEAT)
 HOSTNAMES = {
-    "NUHEAT": "mynuheat.com",
-    "MAPEHEAT": "mymapeheat.com",
+    NUHEAT: "mynuheat.com",
+    MAPEHEAT: "mymapeheat.com",
 }
 API_URL = "https://{HOSTNAME}/api"
 

--- a/nuheat/config.py
+++ b/nuheat/config.py
@@ -1,15 +1,22 @@
-API_URL = "https://www.mynuheat.com/api"
-
-AUTH_URL = API_URL + "/authenticate/user"
-THERMOSTAT_URL = API_URL + "/thermostat"
-
-REQUEST_HEADERS = {
-    "Content-Type": "application/x-www-form-urlencoded",
-    "Accept": "application/json",
-    "Host": "mynuheat.com",
-    "DNT": "1",
-    "Origin": "https://mynuheat.com/api"
+BRANDS = ("NUHEAT", "MAPEHEAT")
+HOSTNAMES = {
+    "NUHEAT": "mynuheat.com",
+    "MAPEHEAT": "mymapeheat.com",
 }
+API_URL = "https://{HOSTNAME}/api"
+
+AUTH_URL = "{API_URL}/authenticate/user"
+THERMOSTAT_URL = "{API_URL}/thermostat"
+
+def get_request_headers(brand="NUHEAT"):
+    brand = brand if brand in BRANDS else BRANDS[0]
+    return {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Accept": "application/json",
+        "Host": "{HOSTNAME}".format(HOSTNAME=HOSTNAMES[brand]),
+        "DNT": "1",
+        "Origin": "https://{HOSTNAME}/api".format(HOSTNAME=HOSTNAMES[brand]),
+    }
 
 # NuHeat Schedule Modes
 SCHEDULE_RUN = 1

--- a/nuheat/thermostat.py
+++ b/nuheat/thermostat.py
@@ -140,10 +140,7 @@ class NuHeatThermostat(object):
             "serialnumber": self.serial_number
         }
         data = self._session.request(
-            url=get_thermostat_url(
-                config=config,
-                brand=self._session._brand,
-            ),
+            url=get_thermostat_url(brand=self._session._brand),
             params=params,
         )
 
@@ -346,10 +343,7 @@ class NuHeatThermostat(object):
             "serialnumber": self.serial_number
         }
         self._session.request(
-            url=get_thermostat_url(
-                config=config,
-                brand=self._session._brand,
-            ),
+            url=get_thermostat_url(brand=self._session._brand),
             method="POST",
             data=post_data,
             params=params,

--- a/nuheat/thermostat.py
+++ b/nuheat/thermostat.py
@@ -3,6 +3,7 @@ import nuheat.config as config
 from nuheat.util import (
     celsius_to_nuheat,
     fahrenheit_to_nuheat,
+    get_thermostat_url,
     nuheat_to_celsius,
     nuheat_to_fahrenheit
 )
@@ -139,7 +140,10 @@ class NuHeatThermostat(object):
             "serialnumber": self.serial_number
         }
         data = self._session.request(
-            url=config.THERMOSTAT_URL.format(API_URL=self._session._api_url),
+            url=get_thermostat_url(
+                config=config,
+                brand=self._session._brand,
+            ),
             params=params,
         )
 
@@ -341,4 +345,12 @@ class NuHeatThermostat(object):
         params = {
             "serialnumber": self.serial_number
         }
-        self._session.request(config.THERMOSTAT_URL, method="POST", data=post_data, params=params)
+        self._session.request(
+            url=get_thermostat_url(
+                config=config,
+                brand=self._session._brand,
+            ),
+            method="POST",
+            data=post_data,
+            params=params,
+        )

--- a/nuheat/thermostat.py
+++ b/nuheat/thermostat.py
@@ -138,7 +138,10 @@ class NuHeatThermostat(object):
         params = {
             "serialnumber": self.serial_number
         }
-        data = self._session.request(config.THERMOSTAT_URL, params=params)
+        data = self._session.request(
+            url=config.THERMOSTAT_URL.format(API_URL=self._session._api_url),
+            params=params,
+        )
 
         self._data = data
 

--- a/nuheat/thermostat.py
+++ b/nuheat/thermostat.py
@@ -3,7 +3,6 @@ import nuheat.config as config
 from nuheat.util import (
     celsius_to_nuheat,
     fahrenheit_to_nuheat,
-    get_thermostat_url,
     nuheat_to_celsius,
     nuheat_to_fahrenheit
 )
@@ -40,6 +39,17 @@ class NuHeatThermostat(object):
             self.target_fahrenheit,
             self.target_celsius
         )
+
+    @classmethod
+    def get_url(cls, api_url):
+        """
+        A helper method to solve a circular dependency when testing
+        """
+        return f"{api_url}/thermostat"
+
+    @property
+    def _url(self):
+        return self.get_url(self._session._api_url)
 
     @property
     def fahrenheit(self):
@@ -140,7 +150,7 @@ class NuHeatThermostat(object):
             "serialnumber": self.serial_number
         }
         data = self._session.request(
-            url=get_thermostat_url(brand=self._session._brand),
+            url=self._url,
             params=params,
         )
 
@@ -343,7 +353,7 @@ class NuHeatThermostat(object):
             "serialnumber": self.serial_number
         }
         self._session.request(
-            url=get_thermostat_url(brand=self._session._brand),
+            url=self._url,
             method="POST",
             data=post_data,
             params=params,

--- a/nuheat/util.py
+++ b/nuheat/util.py
@@ -1,5 +1,7 @@
 from decimal import Decimal, ROUND_HALF_UP
 
+from nuheat import config
+
 
 def round_half(number):
     """
@@ -69,28 +71,28 @@ def nuheat_to_celsius(nuheat_temperature):
     fahrenheit = nuheat_to_fahrenheit(nuheat_temperature)
     return fahrenheit_to_celsius(fahrenheit)
 
-def get_api_url(config, brand="NUHEAT"):
+def get_api_url(brand=config.NUHEAT):
     brand = brand if brand in config.BRANDS else config.BRANDS[0]
     return config.API_URL.format(HOSTNAME=config.HOSTNAMES.get(brand))
 
-def get_auth_url(config, brand="NUHEAT"):
+def get_auth_url(brand=config.NUHEAT):
     brand = brand if brand in config.BRANDS else config.BRANDS[0]
     return config.AUTH_URL.format(
-        API_URL=get_api_url(config=config, brand=brand)
+        API_URL=get_api_url(brand=brand)
     )
 
-def get_thermostat_url(config, brand="NUHEAT"):
+def get_thermostat_url(brand=config.NUHEAT):
     brand = brand if brand in config.BRANDS else config.BRANDS[0]
     return config.THERMOSTAT_URL.format(
-        API_URL=get_api_url(config=config, brand=brand)
+        API_URL=get_api_url(brand=brand)
     )
 
-def get_request_headers(config, brand="NUHEAT"):
+def get_request_headers(brand=config.NUHEAT):
     brand = brand if brand in config.BRANDS else config.BRANDS[0]
     return {
         "Content-Type": "application/x-www-form-urlencoded",
         "Accept": "application/json",
         "HOST": config.HOSTNAMES[brand],
         "DNT": "1",
-        "Origin": get_api_url(config=config, brand=brand),
+        "Origin": get_api_url(brand=brand),
     }

--- a/nuheat/util.py
+++ b/nuheat/util.py
@@ -68,3 +68,29 @@ def nuheat_to_celsius(nuheat_temperature):
     """
     fahrenheit = nuheat_to_fahrenheit(nuheat_temperature)
     return fahrenheit_to_celsius(fahrenheit)
+
+def get_api_url(config, brand="NUHEAT"):
+    brand = brand if brand in config.BRANDS else config.BRANDS[0]
+    return config.API_URL.format(HOSTNAME=config.HOSTNAMES.get(brand))
+
+def get_auth_url(config, brand="NUHEAT"):
+    brand = brand if brand in config.BRANDS else config.BRANDS[0]
+    return config.AUTH_URL.format(
+        API_URL=get_api_url(config=config, brand=brand)
+    )
+
+def get_thermostat_url(config, brand="NUHEAT"):
+    brand = brand if brand in config.BRANDS else config.BRANDS[0]
+    return config.THERMOSTAT_URL.format(
+        API_URL=get_api_url(config=config, brand=brand)
+    )
+
+def get_request_headers(config, brand="NUHEAT"):
+    brand = brand if brand in config.BRANDS else config.BRANDS[0]
+    return {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Accept": "application/json",
+        "HOST": config.HOSTNAMES[brand],
+        "DNT": "1",
+        "Origin": get_api_url(config=config, brand=brand),
+    }

--- a/nuheat/util.py
+++ b/nuheat/util.py
@@ -1,7 +1,5 @@
 from decimal import Decimal, ROUND_HALF_UP
 
-from nuheat import config
-
 
 def round_half(number):
     """
@@ -70,29 +68,3 @@ def nuheat_to_celsius(nuheat_temperature):
     """
     fahrenheit = nuheat_to_fahrenheit(nuheat_temperature)
     return fahrenheit_to_celsius(fahrenheit)
-
-def get_api_url(brand=config.NUHEAT):
-    brand = brand if brand in config.BRANDS else config.BRANDS[0]
-    return config.API_URL.format(HOSTNAME=config.HOSTNAMES.get(brand))
-
-def get_auth_url(brand=config.NUHEAT):
-    brand = brand if brand in config.BRANDS else config.BRANDS[0]
-    return config.AUTH_URL.format(
-        API_URL=get_api_url(brand=brand)
-    )
-
-def get_thermostat_url(brand=config.NUHEAT):
-    brand = brand if brand in config.BRANDS else config.BRANDS[0]
-    return config.THERMOSTAT_URL.format(
-        API_URL=get_api_url(brand=brand)
-    )
-
-def get_request_headers(brand=config.NUHEAT):
-    brand = brand if brand in config.BRANDS else config.BRANDS[0]
-    return {
-        "Content-Type": "application/x-www-form-urlencoded",
-        "Accept": "application/json",
-        "HOST": config.HOSTNAMES[brand],
-        "DNT": "1",
-        "Origin": get_api_url(brand=brand),
-    }

--- a/tests/test_nuheat.py
+++ b/tests/test_nuheat.py
@@ -4,7 +4,7 @@ import responses
 from mock import patch
 from urllib.parse import urlencode
 
-from nuheat import NuHeat, NuHeatThermostat, config, util
+from nuheat import NuHeat, NuHeatThermostat
 from . import NuTestCase, load_fixture
 
 
@@ -24,32 +24,34 @@ class TestNuHeat(NuTestCase):
 
     @responses.activate
     def test_successful_authentication(self):
+        api = NuHeat("test@example.com", "secure-password")
+
         response_data = load_fixture("auth_success.json")
         responses.add(
             responses.POST,
-            util.get_auth_url(),
+            api._auth_url,
             status=200,
             body=json.dumps(response_data),
             content_type="application/json"
         )
 
-        api = NuHeat("test@example.com", "secure-password")
         self.assertIsNone(api._session_id)
         api.authenticate()
         self.assertEqual(api._session_id, response_data.get("SessionId"))
 
     @responses.activate
     def test_authentication_error(self):
+        api = NuHeat("test@example.com", "secure-password")
+
         response_data = load_fixture("auth_error.json")
         responses.add(
             responses.POST,
-            util.get_auth_url(),
+            api._auth_url,
             status=200,
             body=json.dumps(response_data),
             content_type="application/json"
         )
 
-        api = NuHeat("test@example.com", "secure-password")
         with self.assertRaises(Exception) as _:
             api.authenticate()
             self.assertIsNone(api._session_id)
@@ -83,11 +85,11 @@ class TestNuHeat(NuTestCase):
         request_headers = response.request.headers
         self.assertEqual(
             request_headers["Origin"],
-            util.get_request_headers()["Origin"],
+            api._request_headers["Origin"],
         )
         self.assertEqual(
             request_headers["Content-Type"],
-            util.get_request_headers()["Content-Type"],
+            api._request_headers["Content-Type"],
         )
 
     @responses.activate
@@ -110,9 +112,9 @@ class TestNuHeat(NuTestCase):
         request_headers = response.request.headers
         self.assertEqual(
             request_headers["Origin"],
-            util.get_request_headers()["Origin"],
+            api._request_headers["Origin"],
         )
         self.assertEqual(
             request_headers["Content-Type"],
-            util.get_request_headers()["Content-Type"],
+            api._request_headers["Content-Type"],
         )

--- a/tests/test_nuheat.py
+++ b/tests/test_nuheat.py
@@ -27,7 +27,7 @@ class TestNuHeat(NuTestCase):
         response_data = load_fixture("auth_success.json")
         responses.add(
             responses.POST,
-            util.get_auth_url(config=config),
+            util.get_auth_url(),
             status=200,
             body=json.dumps(response_data),
             content_type="application/json"
@@ -43,7 +43,7 @@ class TestNuHeat(NuTestCase):
         response_data = load_fixture("auth_error.json")
         responses.add(
             responses.POST,
-            util.get_auth_url(config=config),
+            util.get_auth_url(),
             status=200,
             body=json.dumps(response_data),
             content_type="application/json"
@@ -83,11 +83,11 @@ class TestNuHeat(NuTestCase):
         request_headers = response.request.headers
         self.assertEqual(
             request_headers["Origin"],
-            util.get_request_headers(config=config)["Origin"],
+            util.get_request_headers()["Origin"],
         )
         self.assertEqual(
             request_headers["Content-Type"],
-            util.get_request_headers(config=config)["Content-Type"],
+            util.get_request_headers()["Content-Type"],
         )
 
     @responses.activate
@@ -110,9 +110,9 @@ class TestNuHeat(NuTestCase):
         request_headers = response.request.headers
         self.assertEqual(
             request_headers["Origin"],
-            util.get_request_headers(config=config)["Origin"],
+            util.get_request_headers()["Origin"],
         )
         self.assertEqual(
             request_headers["Content-Type"],
-            util.get_request_headers(config=config)["Content-Type"],
+            util.get_request_headers()["Content-Type"],
         )

--- a/tests/test_nuheat.py
+++ b/tests/test_nuheat.py
@@ -27,7 +27,7 @@ class TestNuHeat(NuTestCase):
         response_data = load_fixture("auth_success.json")
         responses.add(
             responses.POST,
-            config.AUTH_URL,
+            util.get_auth_url(config=config),
             status=200,
             body=json.dumps(response_data),
             content_type="application/json"
@@ -43,7 +43,7 @@ class TestNuHeat(NuTestCase):
         response_data = load_fixture("auth_error.json")
         responses.add(
             responses.POST,
-            config.AUTH_URL,
+            util.get_auth_url(config=config),
             status=200,
             body=json.dumps(response_data),
             content_type="application/json"
@@ -81,8 +81,14 @@ class TestNuHeat(NuTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertUrlsEqual(response.request.url, "{}?{}".format(url, urlencode(params)))
         request_headers = response.request.headers
-        self.assertEqual(request_headers["Origin"], config.REQUEST_HEADERS["Origin"])
-        self.assertEqual(request_headers["Content-Type"], config.REQUEST_HEADERS["Content-Type"])
+        self.assertEqual(
+            request_headers["Origin"],
+            util.get_request_headers(config=config)["Origin"],
+        )
+        self.assertEqual(
+            request_headers["Content-Type"],
+            util.get_request_headers(config=config)["Content-Type"],
+        )
 
     @responses.activate
     def test_post_request(self):
@@ -102,5 +108,11 @@ class TestNuHeat(NuTestCase):
         self.assertUrlsEqual(response.request.url, "{}?{}".format(url, urlencode(params)))
         self.assertEqual(response.request.body, urlencode(data))
         request_headers = response.request.headers
-        self.assertEqual(request_headers["Origin"], config.REQUEST_HEADERS["Origin"])
-        self.assertEqual(request_headers["Content-Type"], config.REQUEST_HEADERS["Content-Type"])
+        self.assertEqual(
+            request_headers["Origin"],
+            util.get_request_headers(config=config)["Origin"],
+        )
+        self.assertEqual(
+            request_headers["Content-Type"],
+            util.get_request_headers(config=config)["Content-Type"],
+        )

--- a/tests/test_nuheat.py
+++ b/tests/test_nuheat.py
@@ -4,7 +4,7 @@ import responses
 from mock import patch
 from urllib.parse import urlencode
 
-from nuheat import NuHeat, NuHeatThermostat, config
+from nuheat import NuHeat, NuHeatThermostat, config, util
 from . import NuTestCase, load_fixture
 
 

--- a/tests/test_thermostat.py
+++ b/tests/test_thermostat.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone, timedelta
 from mock import patch
 from urllib.parse import urlencode
 
-from nuheat import NuHeat, NuHeatThermostat, config
+from nuheat import NuHeat, NuHeatThermostat, config, util
 from . import NuTestCase, load_fixture
 
 
@@ -394,7 +394,7 @@ class TestThermostat(NuTestCase):
         response_data = load_fixture("thermostat.json")
         responses.add(
             responses.GET,
-            config.THERMOSTAT_URL,
+            util.get_thermostat_url(config=config),
             status=200,
             body=json.dumps(response_data),
             content_type="application/json"
@@ -479,7 +479,7 @@ class TestThermostat(NuTestCase):
         response_data = load_fixture("thermostat.json")
         responses.add(
             responses.GET,
-            config.THERMOSTAT_URL,
+            util.get_thermostat_url(config=config),
             status=200,
             body=json.dumps(response_data),
             content_type="application/json"

--- a/tests/test_thermostat.py
+++ b/tests/test_thermostat.py
@@ -124,25 +124,29 @@ class TestThermostat(NuTestCase):
     @responses.activate
     def test_get_data(self):
         response_data = load_fixture("thermostat.json")
+
+        api = NuHeat(None, None, session_id="my-session")
+
         responses.add(
             responses.GET,
-            util.get_thermostat_url(),
+            NuHeatThermostat.get_url(api._api_url),
             status=200,
             body=json.dumps(response_data),
             content_type="application/json"
         )
-        api = NuHeat(None, None, session_id="my-session")
+
         serial_number = response_data.get("SerialNumber")
+        thermostat = NuHeatThermostat(api, serial_number)
+
         params = {
             "sessionid": api._session_id,
             "serialnumber": serial_number
         }
         request_url = "{}?{}".format(
-            util.get_thermostat_url(),
+            thermostat._url,
             urlencode(params),
         )
 
-        thermostat = NuHeatThermostat(api, serial_number)
         thermostat.get_data()
 
         api_calls = responses.calls
@@ -169,26 +173,33 @@ class TestThermostat(NuTestCase):
     def test_get_data_401(self):
         # First request (when initializing the thermostat) is successful
         response_data = load_fixture("thermostat.json")
+        auth_data = load_fixture("auth_success.json")
+
+        bad_session_id = "my-bad-session"
+        good_session_id = auth_data.get("SessionId")
+        api = NuHeat(None, None, session_id=bad_session_id)
         responses.add(
             responses.GET,
-            util.get_thermostat_url(),
+            NuHeatThermostat.get_url(api._api_url),
             status=200,
             body=json.dumps(response_data),
             content_type="application/json"
         )
 
+        serial_number = response_data.get("SerialNumber")
+        thermostat = NuHeatThermostat(api, serial_number)
+
         # A later, second request throws 401 Unauthorized
         responses.add(
             responses.GET,
-            util.get_thermostat_url(),
+            thermostat._url,
             status=401
         )
 
         # Attempt to reauthenticate
-        auth_data = load_fixture("auth_success.json")
         responses.add(
             responses.POST,
-            util.get_auth_url(),
+            api._auth_url,
             status=200,
             body=json.dumps(auth_data),
             content_type="application/json"
@@ -197,18 +208,12 @@ class TestThermostat(NuTestCase):
         # Third request is successful
         responses.add(
             responses.GET,
-            util.get_thermostat_url(),
+            thermostat._url,
             status=200,
             body=json.dumps(response_data),
             content_type="application/json"
         )
 
-        bad_session_id = "my-bad-session"
-        good_session_id = auth_data.get("SessionId")
-        api = NuHeat(None, None, session_id=bad_session_id)
-        serial_number = response_data.get("SerialNumber")
-
-        thermostat = NuHeatThermostat(api, serial_number)
         thermostat.get_data()
         self.assertTrue(isinstance(thermostat, NuHeatThermostat))
 
@@ -218,7 +223,7 @@ class TestThermostat(NuTestCase):
         unauthorized_attempt = api_calls[1]
         params = {"sessionid": bad_session_id, "serialnumber": serial_number}
         request_url = "{}?{}".format(
-            util.get_thermostat_url(),
+            thermostat._url,
             urlencode(params),
         )
         self.assertEqual(unauthorized_attempt.request.method, "GET")
@@ -229,13 +234,13 @@ class TestThermostat(NuTestCase):
         self.assertEqual(auth_call.request.method, "POST")
         self.assertUrlsEqual(
             auth_call.request.url,
-            util.get_auth_url()
+            api._auth_url,
         )
 
         second_attempt = api_calls[3]
         params["sessionid"] = good_session_id
         request_url = "{}?{}".format(
-            util.get_thermostat_url(),
+            thermostat._url,
             urlencode(params),
         )
         self.assertEqual(second_attempt.request.method, "GET")
@@ -392,16 +397,17 @@ class TestThermostat(NuTestCase):
     def test_next_schedule_event(self):
         # Use thermostat.json to load a schedule into thermostat
         response_data = load_fixture("thermostat.json")
+
+        api = NuHeat(None, None, session_id="my-session")
         responses.add(
             responses.GET,
-            util.get_thermostat_url(),
+            NuHeatThermostat.get_url(api._api_url),
             status=200,
             body=json.dumps(response_data),
             content_type="application/json"
         )
-        api = NuHeat(None, None, session_id="my-session")
-        serial_number = response_data.get("SerialNumber")
 
+        serial_number = response_data.get("SerialNumber")
         thermostat = NuHeatThermostat(api, serial_number)
         thermostat.get_data()
 
@@ -477,17 +483,17 @@ class TestThermostat(NuTestCase):
     @patch("nuheat.NuHeatThermostat.set_data")
     def test_set_target_temperature_temporary_hold_time(self, set_data):
         response_data = load_fixture("thermostat.json")
-        responses.add(
-            responses.GET,
-            util.get_thermostat_url(),
-            status=200,
-            body=json.dumps(response_data),
-            content_type="application/json"
-        )
         api = NuHeat(None, None, session_id="my-session")
         serial_number = response_data.get("SerialNumber")
 
         with patch("nuheat.thermostat.datetime", wraps=datetime) as mock_dt:
+            responses.add(
+                responses.GET,
+                NuHeatThermostat.get_url(api._api_url),
+                status=200,
+                body=json.dumps(response_data),
+                content_type="application/json"
+            )
             thermostat = NuHeatThermostat(api, serial_number)
             thermostat.get_data()
 
@@ -505,25 +511,27 @@ class TestThermostat(NuTestCase):
     @responses.activate
     @patch("nuheat.NuHeatThermostat.get_data")
     def test_set_data(self, _):
+        api = NuHeat(None, None, session_id="my-session")
+
         responses.add(
             responses.POST,
-            util.get_thermostat_url(),
+            NuHeatThermostat.get_url(api._api_url),
             status=200,
             content_type="application/json"
         )
 
-        api = NuHeat(None, None, session_id="my-session")
         serial_number = "my-thermostat"
+        thermostat = NuHeatThermostat(api, serial_number)
+
         params = {
             "sessionid": api._session_id,
             "serialnumber": serial_number
         }
         request_url = "{}?{}".format(
-            util.get_thermostat_url(),
+            thermostat._url,
             urlencode(params),
         )
         post_data = {"test": "data"}
-        thermostat = NuHeatThermostat(api, serial_number)
         thermostat.set_data(post_data)
 
         api_call = responses.calls[0]

--- a/tests/test_thermostat.py
+++ b/tests/test_thermostat.py
@@ -126,7 +126,7 @@ class TestThermostat(NuTestCase):
         response_data = load_fixture("thermostat.json")
         responses.add(
             responses.GET,
-            util.get_thermostat_url(config=config),
+            util.get_thermostat_url(),
             status=200,
             body=json.dumps(response_data),
             content_type="application/json"
@@ -138,7 +138,7 @@ class TestThermostat(NuTestCase):
             "serialnumber": serial_number
         }
         request_url = "{}?{}".format(
-            util.get_thermostat_url(config=config),
+            util.get_thermostat_url(),
             urlencode(params),
         )
 
@@ -171,7 +171,7 @@ class TestThermostat(NuTestCase):
         response_data = load_fixture("thermostat.json")
         responses.add(
             responses.GET,
-            util.get_thermostat_url(config=config),
+            util.get_thermostat_url(),
             status=200,
             body=json.dumps(response_data),
             content_type="application/json"
@@ -180,7 +180,7 @@ class TestThermostat(NuTestCase):
         # A later, second request throws 401 Unauthorized
         responses.add(
             responses.GET,
-            util.get_thermostat_url(config=config),
+            util.get_thermostat_url(),
             status=401
         )
 
@@ -188,7 +188,7 @@ class TestThermostat(NuTestCase):
         auth_data = load_fixture("auth_success.json")
         responses.add(
             responses.POST,
-            util.get_auth_url(config=config),
+            util.get_auth_url(),
             status=200,
             body=json.dumps(auth_data),
             content_type="application/json"
@@ -197,7 +197,7 @@ class TestThermostat(NuTestCase):
         # Third request is successful
         responses.add(
             responses.GET,
-            util.get_thermostat_url(config=config),
+            util.get_thermostat_url(),
             status=200,
             body=json.dumps(response_data),
             content_type="application/json"
@@ -218,7 +218,7 @@ class TestThermostat(NuTestCase):
         unauthorized_attempt = api_calls[1]
         params = {"sessionid": bad_session_id, "serialnumber": serial_number}
         request_url = "{}?{}".format(
-            util.get_thermostat_url(config=config),
+            util.get_thermostat_url(),
             urlencode(params),
         )
         self.assertEqual(unauthorized_attempt.request.method, "GET")
@@ -229,13 +229,13 @@ class TestThermostat(NuTestCase):
         self.assertEqual(auth_call.request.method, "POST")
         self.assertUrlsEqual(
             auth_call.request.url,
-            util.get_auth_url(config=config)
+            util.get_auth_url()
         )
 
         second_attempt = api_calls[3]
         params["sessionid"] = good_session_id
         request_url = "{}?{}".format(
-            util.get_thermostat_url(config=config),
+            util.get_thermostat_url(),
             urlencode(params),
         )
         self.assertEqual(second_attempt.request.method, "GET")
@@ -394,7 +394,7 @@ class TestThermostat(NuTestCase):
         response_data = load_fixture("thermostat.json")
         responses.add(
             responses.GET,
-            util.get_thermostat_url(config=config),
+            util.get_thermostat_url(),
             status=200,
             body=json.dumps(response_data),
             content_type="application/json"
@@ -479,7 +479,7 @@ class TestThermostat(NuTestCase):
         response_data = load_fixture("thermostat.json")
         responses.add(
             responses.GET,
-            util.get_thermostat_url(config=config),
+            util.get_thermostat_url(),
             status=200,
             body=json.dumps(response_data),
             content_type="application/json"
@@ -507,7 +507,7 @@ class TestThermostat(NuTestCase):
     def test_set_data(self, _):
         responses.add(
             responses.POST,
-            util.get_thermostat_url(config=config),
+            util.get_thermostat_url(),
             status=200,
             content_type="application/json"
         )
@@ -519,7 +519,7 @@ class TestThermostat(NuTestCase):
             "serialnumber": serial_number
         }
         request_url = "{}?{}".format(
-            util.get_thermostat_url(config=config),
+            util.get_thermostat_url(),
             urlencode(params),
         )
         post_data = {"test": "data"}

--- a/tests/test_thermostat.py
+++ b/tests/test_thermostat.py
@@ -126,7 +126,7 @@ class TestThermostat(NuTestCase):
         response_data = load_fixture("thermostat.json")
         responses.add(
             responses.GET,
-            config.THERMOSTAT_URL,
+            util.get_thermostat_url(config=config),
             status=200,
             body=json.dumps(response_data),
             content_type="application/json"
@@ -137,7 +137,10 @@ class TestThermostat(NuTestCase):
             "sessionid": api._session_id,
             "serialnumber": serial_number
         }
-        request_url = "{}?{}".format(config.THERMOSTAT_URL, urlencode(params))
+        request_url = "{}?{}".format(
+            util.get_thermostat_url(config=config),
+            urlencode(params),
+        )
 
         thermostat = NuHeatThermostat(api, serial_number)
         thermostat.get_data()
@@ -168,7 +171,7 @@ class TestThermostat(NuTestCase):
         response_data = load_fixture("thermostat.json")
         responses.add(
             responses.GET,
-            config.THERMOSTAT_URL,
+            util.get_thermostat_url(config=config),
             status=200,
             body=json.dumps(response_data),
             content_type="application/json"
@@ -177,7 +180,7 @@ class TestThermostat(NuTestCase):
         # A later, second request throws 401 Unauthorized
         responses.add(
             responses.GET,
-            config.THERMOSTAT_URL,
+            util.get_thermostat_url(config=config),
             status=401
         )
 
@@ -185,7 +188,7 @@ class TestThermostat(NuTestCase):
         auth_data = load_fixture("auth_success.json")
         responses.add(
             responses.POST,
-            config.AUTH_URL,
+            util.get_auth_url(config=config),
             status=200,
             body=json.dumps(auth_data),
             content_type="application/json"
@@ -194,7 +197,7 @@ class TestThermostat(NuTestCase):
         # Third request is successful
         responses.add(
             responses.GET,
-            config.THERMOSTAT_URL,
+            util.get_thermostat_url(config=config),
             status=200,
             body=json.dumps(response_data),
             content_type="application/json"
@@ -214,18 +217,27 @@ class TestThermostat(NuTestCase):
 
         unauthorized_attempt = api_calls[1]
         params = {"sessionid": bad_session_id, "serialnumber": serial_number}
-        request_url = "{}?{}".format(config.THERMOSTAT_URL, urlencode(params))
+        request_url = "{}?{}".format(
+            util.get_thermostat_url(config=config),
+            urlencode(params),
+        )
         self.assertEqual(unauthorized_attempt.request.method, "GET")
         self.assertUrlsEqual(unauthorized_attempt.request.url, request_url)
         self.assertEqual(unauthorized_attempt.response.status_code, 401)
 
         auth_call = api_calls[2]
         self.assertEqual(auth_call.request.method, "POST")
-        self.assertUrlsEqual(auth_call.request.url, config.AUTH_URL)
+        self.assertUrlsEqual(
+            auth_call.request.url,
+            util.get_auth_url(config=config)
+        )
 
         second_attempt = api_calls[3]
         params["sessionid"] = good_session_id
-        request_url = "{}?{}".format(config.THERMOSTAT_URL, urlencode(params))
+        request_url = "{}?{}".format(
+            util.get_thermostat_url(config=config),
+            urlencode(params),
+        )
         self.assertEqual(second_attempt.request.method, "GET")
         self.assertUrlsEqual(second_attempt.request.url, request_url)
         self.assertEqual(second_attempt.response.status_code, 200)
@@ -495,7 +507,7 @@ class TestThermostat(NuTestCase):
     def test_set_data(self, _):
         responses.add(
             responses.POST,
-            config.THERMOSTAT_URL,
+            util.get_thermostat_url(config=config),
             status=200,
             content_type="application/json"
         )
@@ -506,7 +518,10 @@ class TestThermostat(NuTestCase):
             "sessionid": api._session_id,
             "serialnumber": serial_number
         }
-        request_url = "{}?{}".format(config.THERMOSTAT_URL, urlencode(params))
+        request_url = "{}?{}".format(
+            util.get_thermostat_url(config=config),
+            urlencode(params),
+        )
         post_data = {"test": "data"}
         thermostat = NuHeatThermostat(api, serial_number)
         thermostat.set_data(post_data)


### PR DESCRIPTION
Support new thermostats under the Mape Heat brand. The library defaults to using the original NuHeat API if no new arguments are used.

closes #4 