### PR TITLE
remove dependency on old external mock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
     'dev': [
       'coveralls==3.3.1',
       'coverage==6.5.0',
-      'mock==4.0.3',
       'parameterized==0.8.1',
       'pytest==7.2.0',
       'pytest-cov==4.0.0',

--- a/tests/test_nuheat.py
+++ b/tests/test_nuheat.py
@@ -1,7 +1,7 @@
 import json
 import responses
 
-from mock import patch
+from unittest.mock import patch
 from parameterized import parameterized
 from urllib.parse import urlencode
 

--- a/tests/test_thermostat.py
+++ b/tests/test_thermostat.py
@@ -2,7 +2,7 @@ import json
 import responses
 
 from datetime import datetime, timezone, timedelta
-from mock import patch
+from unittest.mock import patch
 from parameterized import parameterized
 from urllib.parse import urlencode
 


### PR DESCRIPTION
mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.

https://github.com/testing-cabal/mock